### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,11 @@ on:
       Solar2DBuild:
         description: 'Solar2D Build Number'
         required: true
-        default: '2023.3691'
+        default: '2024.3706'
       Xcode:
         description: 'Xcode Version'
         required: true
-        default: '14.3'
+        default: '15.2'
 
 
 env:


### PR DESCRIPTION
Dear @Shchvova 

It is an update for the new requirement of apple : 
"
All iOS and iPadOS apps must be built with the iOS 17 SDK or later, included in Xcode 15 or later, in order to be uploaded to App Store Connect or submitted for distribution. "

Sincerely.